### PR TITLE
Recover TGeoManager::fIsOutside for transf. tracks

### DIFF
--- a/source/include/TMCManager.h
+++ b/source/include/TMCManager.h
@@ -106,10 +106,10 @@ public:
    void TransferTrack(TVirtualMC *mc);
 
    /// Try to restore geometry for a given track
-   Bool_t TryRestoreGeometryState(Int_t trackId);
+   Bool_t RestoreGeometryState(Int_t trackId, Bool_t checkTrackIdRange = kTRUE);
 
    /// Try to restore geometry for the track currently set
-   Bool_t TryRestoreGeometryState();
+   Bool_t RestoreGeometryState();
 
    //
    // Steering and control

--- a/source/include/TMCManager.h
+++ b/source/include/TMCManager.h
@@ -105,6 +105,12 @@ public:
    /// Transfer track from current engine to target engine mc
    void TransferTrack(TVirtualMC *mc);
 
+   /// Try to restore geometry for a given track
+   Bool_t TryRestoreGeometryState(Int_t trackId);
+
+   /// Try to restore geometry for the track currently set
+   Bool_t TryRestoreGeometryState();
+
    //
    // Steering and control
    //

--- a/source/include/TMCManagerStack.h
+++ b/source/include/TMCManagerStack.h
@@ -111,15 +111,6 @@ public:
    /// Get current particle's geometry status
    const TGeoBranchArray *GetCurrentGeoState() const;
 
-   //
-   // Action methods
-   //
-
-   /// To free the cached geo state which was associated to a track
-   void NotifyOnRestoredGeometry(Int_t trackId);
-   /// To free the cached geo state which was associated to the current track
-   void NotifyOnRestoredGeometry();
-
 private:
    friend class TMCManager;
    /// Check whether track trackId exists

--- a/source/include/TMCParticleStatus.h
+++ b/source/include/TMCParticleStatus.h
@@ -90,6 +90,8 @@ struct TMCParticleStatus {
    Int_t fId = -1;
    /// Unique ID assigned by the user
    Int_t fParentId = -1;
+   /// Flags to (re)set for TGeoNavigator's fIsOutside state
+   Bool_t fIsOutside;
 
 private:
    /// Copying kept private

--- a/source/include/TVirtualMC.h
+++ b/source/include/TVirtualMC.h
@@ -873,12 +873,6 @@ public:
    /// Check whether external particle generation should be used
    Bool_t UseExternalParticleGeneration() const { return fUseExternalParticleGeneration; }
 
-   /// Try to restore geometry for a given track
-   Bool_t TryRestoreGeometryState(Int_t trackId);
-
-   /// Try to restore geometry for the track currently set
-   Bool_t TryRestoreGeometryState();
-
 private:
    /// Set the VMC id
    void SetId(UInt_t id);

--- a/source/include/TVirtualMC.h
+++ b/source/include/TVirtualMC.h
@@ -873,6 +873,12 @@ public:
    /// Check whether external particle generation should be used
    Bool_t UseExternalParticleGeneration() const { return fUseExternalParticleGeneration; }
 
+   /// Try to restore geometry for a given track
+   Bool_t TryRestoreGeometryState(Int_t trackId);
+
+   /// Try to restore geometry for the track currently set
+   Bool_t TryRestoreGeometryState();
+
 private:
    /// Set the VMC id
    void SetId(UInt_t id);

--- a/source/src/TMCManager.cxx
+++ b/source/src/TMCManager.cxx
@@ -313,6 +313,9 @@ void TMCManager::TransferTrack(TVirtualMC *mc)
    fParticlesStatus[trackId]->fTrackLength = fCurrentEngine->TrackLength();
    fParticlesStatus[trackId]->fWeight = fCurrentEngine->TrackWeight();
 
+   // Store TGeoNavidator's fIsOutside state
+   fParticlesStatus[trackId]->fIsOutside = gGeoManager->IsOutside();
+
    TGeoBranchArray *geoState = fBranchArrayContainer.GetNewGeoState(fParticlesStatus[trackId]->fGeoStateIndex);
    geoState->InitFromNavigator(gGeoManager->GetCurrentNavigator());
 
@@ -323,6 +326,38 @@ void TMCManager::TransferTrack(TVirtualMC *mc)
       fStacks[mc->GetId()]->PushSecondaryTrackId(trackId);
    }
    fCurrentEngine->InterruptTrack();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Try to restore geometry for a given track
+///
+
+Bool_t TMCManager::TryRestoreGeometryState(Int_t trackId)
+{
+  if (trackId < 0 || trackId >= static_cast<Int_t>(fParticles.size()) || !fParticles[trackId]) {
+     return kFALSE;
+  }
+  UInt_t& geoStateId = fParticlesStatus[trackId]->fGeoStateIndex;
+  if(geoStateId == 0) {
+    return kFALSE;
+  }
+  const TGeoBranchArray* branchArray = fBranchArrayContainer.GetGeoState(geoStateId);
+  branchArray->UpdateNavigator(gGeoManager->GetCurrentNavigator());
+  fBranchArrayContainer.FreeGeoState(geoStateId);
+  gGeoManager->SetOutside(fParticlesStatus[trackId]->fIsOutside);
+  geoStateId = 0;
+  return kTRUE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Try to restore geometry for the track currently set
+///
+
+Bool_t TMCManager::TryRestoreGeometryState()
+{
+  return TryRestoreGeometryState(fStacks[fCurrentEngine->GetId()]->GetCurrentTrackNumber());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/source/src/TMCManager.cxx
+++ b/source/src/TMCManager.cxx
@@ -333,9 +333,9 @@ void TMCManager::TransferTrack(TVirtualMC *mc)
 /// Try to restore geometry for a given track
 ///
 
-Bool_t TMCManager::TryRestoreGeometryState(Int_t trackId)
+Bool_t TMCManager::RestoreGeometryState(Int_t trackId, Bool_t checkTrackIdRange)
 {
-  if (trackId < 0 || trackId >= static_cast<Int_t>(fParticles.size()) || !fParticles[trackId]) {
+  if (checkTrackIdRange && (trackId < 0 || trackId >= static_cast<Int_t>(fParticles.size()) || !fParticles[trackId])) {
      return kFALSE;
   }
   UInt_t& geoStateId = fParticlesStatus[trackId]->fGeoStateIndex;
@@ -355,9 +355,9 @@ Bool_t TMCManager::TryRestoreGeometryState(Int_t trackId)
 /// Try to restore geometry for the track currently set
 ///
 
-Bool_t TMCManager::TryRestoreGeometryState()
+Bool_t TMCManager::RestoreGeometryState()
 {
-  return TryRestoreGeometryState(fStacks[fCurrentEngine->GetId()]->GetCurrentTrackNumber());
+  return RestoreGeometryState(fStacks[fCurrentEngine->GetId()]->GetCurrentTrackNumber(), kFALSE);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/source/src/TMCManagerStack.cxx
+++ b/source/src/TMCManagerStack.cxx
@@ -230,31 +230,6 @@ const TGeoBranchArray *TMCManagerStack::GetCurrentGeoState() const
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// To free the cached geo state which was associated to the current track
-///
-
-void TMCManagerStack::NotifyOnRestoredGeometry()
-{
-   fBranchArrayContainer->FreeGeoState(fParticlesStatus->operator[](fCurrentTrackId)->fGeoStateIndex);
-   fParticlesStatus->operator[](fCurrentTrackId)->fGeoStateIndex = 0;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// To free the cached geo state which was associated to a track
-///
-
-void TMCManagerStack::NotifyOnRestoredGeometry(Int_t trackId)
-{
-   if (!HasTrackId(trackId)) {
-      Fatal("NotifyOnRestoredGeometry", "Invalid track ID %i", trackId);
-   }
-   fBranchArrayContainer->FreeGeoState(fParticlesStatus->operator[](trackId)->fGeoStateIndex);
-   fParticlesStatus->operator[](trackId)->fGeoStateIndex = 0;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
 /// Check whether track trackId exists
 ///
 

--- a/source/src/TMCVerbose.cxx
+++ b/source/src/TMCVerbose.cxx
@@ -221,7 +221,7 @@ void TMCVerbose::BeginPrimary()
 
 void TMCVerbose::PreTrack()
 {
-   if (fLevel>2) {
+   if (fLevel>3) {
       PrintBanner();
       PrintTrackInfo();
       PrintBanner();
@@ -232,7 +232,7 @@ void TMCVerbose::PreTrack()
       return;
    }
 
-   if (fLevel>1)
+   if (fLevel>2)
       std::cout << "--- Pre track " << std::endl;
 }
 
@@ -249,7 +249,7 @@ void TMCVerbose::Stepping()
 
       // Step number
       //
-      std::cout << "#" << std::setw(4) << fStepNumber++ << "  ";
+      std::cout << "#" << std::setw(4) << gMC->StepNumber() << "  ";
 
       // Position
       //
@@ -301,7 +301,7 @@ void TMCVerbose::Stepping()
 
 void TMCVerbose::PostTrack()
 {
-   if (fLevel==2)
+   if (fLevel>2)
       std::cout << "--- Post track " << std::endl;
 }
 
@@ -310,7 +310,7 @@ void TMCVerbose::PostTrack()
 
 void TMCVerbose::FinishPrimary()
 {
-   if (fLevel==2)
+   if (fLevel>1)
       std::cout << "--- Finish primary " << std::endl;
 }
 

--- a/source/src/TVirtualMC.cxx
+++ b/source/src/TVirtualMC.cxx
@@ -12,6 +12,7 @@
 
 #include "TVirtualMC.h"
 #include "TError.h"
+#include "TMCManager.h"
 
 /** \class TVirtualMC
     \ingroup vmc
@@ -261,4 +262,32 @@ void TVirtualMC::ProcessEvent(Int_t eventId, Bool_t isInterruptible)
 void TVirtualMC::InterruptTrack()
 {
    Warning("InterruptTrack", "Not implemented.");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Try to restore geometry for a given track
+///
+
+Bool_t TVirtualMC::TryRestoreGeometryState(Int_t trackId)
+{
+   TMCManager* mgr = TMCManager::Instance();
+   if (!mgr) {
+      return kFALSE;
+   }
+   return mgr->TryRestoreGeometryState(trackId);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Try to restore geometry for the track currently set
+///
+
+Bool_t TVirtualMC::TryRestoreGeometryState()
+{
+   TMCManager* mgr = TMCManager::Instance();
+   if (!mgr) {
+      return kFALSE;
+   }
+   return mgr->TryRestoreGeometryState();
 }

--- a/source/src/TVirtualMC.cxx
+++ b/source/src/TVirtualMC.cxx
@@ -263,31 +263,3 @@ void TVirtualMC::InterruptTrack()
 {
    Warning("InterruptTrack", "Not implemented.");
 }
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// Try to restore geometry for a given track
-///
-
-Bool_t TVirtualMC::TryRestoreGeometryState(Int_t trackId)
-{
-   TMCManager* mgr = TMCManager::Instance();
-   if (!mgr) {
-      return kFALSE;
-   }
-   return mgr->TryRestoreGeometryState(trackId);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// Try to restore geometry for the track currently set
-///
-
-Bool_t TVirtualMC::TryRestoreGeometryState()
-{
-   TMCManager* mgr = TMCManager::Instance();
-   if (!mgr) {
-      return kFALSE;
-   }
-   return mgr->TryRestoreGeometryState();
-}


### PR DESCRIPTION
When changing from one engine to the other, the TGeoManager's state
flagging if the geometry has been left might be still set to
fIsOutside == true.
That can be a remnant from the transportation of the former engine. This
state is now cached when tracks are transferred and recovered when
tracks are picked up for tracking again.

TVirtualMC can request the recovery of a geometry state via calling
TVirtualMC::TryRestoreGeometryState(Int_t trackId).
Every further touch of the TGeoManager/TGeoNavigator within the
requesting engine is done in its responsibility.