### PR TITLE
Only rely on presence of TMCManager in multi run

### DIFF
--- a/source/include/TVirtualMC.h
+++ b/source/include/TVirtualMC.h
@@ -874,28 +874,12 @@ public:
    /// Return the VMC's ID
    Int_t GetId() const { return fId; }
 
-   /// Check whether external geometry construction should be used
-   Bool_t UseExternalGeometryConstruction() const { return fUseExternalGeometryConstruction; }
-
-   /// Check whether external particle generation should be used
-   Bool_t UseExternalParticleGeneration() const { return fUseExternalParticleGeneration; }
-
 private:
    /// Set the VMC id
    void SetId(UInt_t id);
 
    /// Set container holding additional information for transported TParticles
    void SetManagerStack(TMCManagerStack *stack);
-
-   /// Disables internal dispatch to TVirtualMCApplication::ConstructGeometry()
-   /// and hence rely on geometry construction being trigeered from outside.
-   void SetExternalGeometryConstruction(Bool_t value = kTRUE);
-
-   /// Disables internal dispatch to TVirtualMCApplication::GeneratePrimaries()
-   /// and tells the engine to not make any implicit assumptions on whether it's
-   /// a primary or a secondary. The track could have even been transported by
-   /// another engine to the current point.
-   void SetExternalParticleGeneration(Bool_t value = kTRUE);
 
    /// An interruptible event can be paused and resumed at any time. It must not
    /// call TVirtualMCApplication::BeginEvent() and ::FinishEvent()
@@ -923,23 +907,17 @@ private:
 #endif
 
 private:
-   Int_t fId;                               //!< Unique identification of this VMC
-                                            // (don't use TObject::SetUniqueId since this
-                                            // is used to uniquely identify TObjects in
-                                            // in general)
-                                            // An ID is given by the running TVirtualMCApp
-                                            // and not by the user.
-   TVirtualMCStack *fStack;                 //!< Particles stack
-   TMCManagerStack *fManagerStack;          //!< Stack handled by the TMCManager
-   TVirtualMCDecayer *fDecayer;             //!< External decayer
-   TRandom *fRandom;                        //!< Random number generator
-   TVirtualMagField *fMagField;             //!< Magnetic field
-   Bool_t fUseExternalGeometryConstruction; //!< Don't attempt to
-                                            // call
-                                            // TVirtualMCApplication
-                                            // hooks related to geometry
-   // construction
-   Bool_t fUseExternalParticleGeneration;
+   Int_t fId;                      //!< Unique identification of this VMC
+                                   // (don't use TObject::SetUniqueId since this
+                                   // is used to uniquely identify TObjects in
+                                   // in general)
+                                   // An ID is given by the running TVirtualMCApp
+                                   // and not by the user.
+   TVirtualMCStack *fStack;        //!< Particles stack
+   TMCManagerStack *fManagerStack; //!< Stack handled by the TMCManager
+   TVirtualMCDecayer *fDecayer;    //!< External decayer
+   TRandom *fRandom;               //!< Random number generator
+   TVirtualMagField *fMagField;    //!< Magnetic field
 
    ClassDef(TVirtualMC, 1) // Interface to Monte Carlo
 };

--- a/source/src/TMCManager.cxx
+++ b/source/src/TMCManager.cxx
@@ -104,10 +104,6 @@ void TMCManager::Register(TVirtualMC *mc)
    fStacks.emplace_back(new TMCManagerStack());
    mc->SetStack(fStacks.back().get());
    mc->SetManagerStack(fStacks.back().get());
-   // Don't attempt to call TVirtualMCApplication hooks related to geometry
-   // construction
-   mc->SetExternalGeometryConstruction();
-   mc->SetExternalParticleGeneration();
    // Must update engine pointers here since during construction of the concrete TVirtualMC
    // implementation the static TVirtualMC::GetMC() or defined gMC might be used.
    UpdateEnginePointers(mc);

--- a/source/src/TVirtualMC.cxx
+++ b/source/src/TVirtualMC.cxx
@@ -44,8 +44,7 @@ TMCThreadLocal TVirtualMC *TVirtualMC::fgMC = nullptr;
 
 TVirtualMC::TVirtualMC(const char *name, const char *title, Bool_t /*isRootGeometrySupported*/)
    : TNamed(name, title), fApplication(nullptr), fId(0), fStack(nullptr), fManagerStack(nullptr), fDecayer(nullptr),
-     fRandom(nullptr), fMagField(nullptr), fUseExternalGeometryConstruction(kFALSE),
-     fUseExternalParticleGeneration(kFALSE)
+     fRandom(nullptr), fMagField(nullptr)
 {
    fApplication = TVirtualMCApplication::Instance();
 
@@ -65,8 +64,7 @@ TVirtualMC::TVirtualMC(const char *name, const char *title, Bool_t /*isRootGeome
 
 TVirtualMC::TVirtualMC()
    : TNamed(), fApplication(nullptr), fId(0), fStack(nullptr), fManagerStack(nullptr), fDecayer(nullptr),
-     fRandom(nullptr), fMagField(nullptr), fUseExternalGeometryConstruction(kFALSE),
-     fUseExternalParticleGeneration(kFALSE)
+     fRandom(nullptr), fMagField(nullptr)
 {
 }
 
@@ -220,28 +218,6 @@ void TVirtualMC::SetId(UInt_t id)
 void TVirtualMC::SetManagerStack(TMCManagerStack *stack)
 {
    fManagerStack = stack;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// Disables internal dispatch to TVirtualMCApplication::ConstructGeometry()
-/// and hence rely on geometry construction being trigeered from outside.
-///
-
-void TVirtualMC::SetExternalGeometryConstruction(Bool_t value)
-{
-   fUseExternalGeometryConstruction = value;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// Disables internal dispatch to TVirtualMCApplication::ConstructGeometry()
-/// and hence rely on geometry construction being trigeered from outside.
-///
-
-void TVirtualMC::SetExternalParticleGeneration(Bool_t value)
-{
-   fUseExternalParticleGeneration = value;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
External primary generation and geometry construction is now always
assumed if and only if the TMCManager has been instantiated.