### PR TITLE
Make Header Paths in Dictionary Relative

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -62,6 +62,9 @@ ROOT_GENERATE_DICTIONARY(
   TVirtualMCSensitiveDetector.h
   TVirtualMCStack.h
   MODULE ${library_name}
+  OPTIONS "-I${CMAKE_INSTALL_PREFIX}/include/${base_name}"
+    -excludePath "${CMAKE_CURRENT_BINARY_DIR}"
+    -excludePath "${PROJECT_SOURCE_DIR}/source"
   LINKDEF include/LinkDef.h)
 
 # Files produced by the dictionary generation

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -45,24 +45,24 @@ include_directories(
 #
 ROOT_GENERATE_DICTIONARY(
   ${library_name}_dict
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TGeoMCBranchArrayContainer.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TGeoMCGeometry.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCAutoLock.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCManager.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCManagerStack.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCOptical.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCParticleStatus.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCParticleType.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCProcess.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCVerbose.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCtls.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TVirtualMC.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TVirtualMCApplication.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TVirtualMCGeometry.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TVirtualMCSensitiveDetector.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TVirtualMCStack.h
+  TGeoMCBranchArrayContainer.h
+  TGeoMCGeometry.h
+  TMCAutoLock.h
+  TMCManager.h
+  TMCManagerStack.h
+  TMCOptical.h
+  TMCParticleStatus.h
+  TMCParticleType.h
+  TMCProcess.h
+  TMCVerbose.h
+  TMCtls.h
+  TVirtualMC.h
+  TVirtualMCApplication.h
+  TVirtualMCGeometry.h
+  TVirtualMCSensitiveDetector.h
+  TVirtualMCStack.h
   MODULE ${library_name}
-  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/include/LinkDef.h)
+  LINKDEF include/LinkDef.h)
 
 # Files produced by the dictionary generation
 SET(root_dict


### PR DESCRIPTION
(I am working in the SDE group at GSI with @MohammadAlTurany and I am currently improving our packaging of vmc.)

According to [these root release notes](https://root.cern/doc/v618/release-notes.html#header-location-and-root_generate_dictionary-root_standard_library_package) the listed headers in `ROOT_GENERATE_DICTIONARY` should use relative paths.

Before this change, the headers are loaded from the source/build tree. If the source/build tree is removed after installation, the headers are not found any more.

With this change, the headers in the install tree are found by the interpreter, when `ROOT_INCLUDE_PATH` is set.