### PR TITLE
Comply with TVirtualMCStack::PopNextTrack logic

### DIFF
--- a/source/src/TMCManagerStack.cxx
+++ b/source/src/TMCManagerStack.cxx
@@ -75,6 +75,7 @@ TParticle *TMCManagerStack::PopNextTrack(Int_t &itrack)
    }
    itrack = mcStack->top();
    mcStack->pop();
+   SetCurrentTrack(itrack);
    return fParticles->operator[](itrack);
 }
 


### PR DESCRIPTION
Don't rely on the user to the engine to set the current track but do it
when the next track is popped via TVirtualMCStack::PopNextTrack(...)