### PR TITLE
Late geometry construction

### DIFF
--- a/source/include/TMCManager.h
+++ b/source/include/TMCManager.h
@@ -200,6 +200,7 @@ private:
    Bool_t fIsInitialized;
    /// Flag if specific initialization for engines was done
    Bool_t fIsInitializedUser;
+   Bool_t fGeometryConstructed;
 
    ClassDef(TMCManager, 0)
 };


### PR DESCRIPTION
* only construct geometry when first TVirtualMC is registered instead of
  when TVirtualMCApplication is registered

* e.g. possible to change parameters until then