### PR TITLE
Updated cmake: Do not allow build against ROOT compiled with vmc enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ include(VMCBuildMode)
 option(BUILD_SHARED_LIBS "Build the dynamic libraries" ON)
 
 #--- Find required packages ----------------------------------------------------
-find_package(ROOT CONFIG COMPONENTS Geom EG REQUIRED)
+include(VMCRequiredPackages)
 
 #--- Utility to defined installation lib directory -----------------------------
 include(VMCInstallLibDir)

--- a/cmake/VMCRequiredPackages.cmake
+++ b/cmake/VMCRequiredPackages.cmake
@@ -1,0 +1,27 @@
+#------------------------------------------------
+# The Geant4 Virtual Monte Carlo package
+# Copyright (C) 2014 Ivana Hrivnacova
+# All rights reserved.
+#
+# For the licensing terms see geant4_vmc/LICENSE.
+# Contact: root-vmc@cern.ch
+#-------------------------------------------------
+
+# Configuration file for CMake build for VMC packages
+# which finds all required and optional packages.
+#
+# I. Hrivnacova, 07/12/2021
+
+#message(STATUS Processing Geant4VMCRequiredPackages)
+
+#-- ROOT (required) ------------------------------------------------------------
+find_package(ROOT CONFIG COMPONENTS Geom EG REQUIRED)
+
+# Cannot mix VMC standalone and vmc in ROOT(deprecated)
+if(ROOT_vmc_FOUND)
+  message(FATAL_ERROR
+          "Cannot use VMC standalone with ROOT built with vmc.")
+endif()
+
+# Root definitions
+include(${ROOT_USE_FILE})

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -19,14 +19,6 @@
 set(base_name vmc)
 set(library_name ${PROJECT_NAME}Library)
 
-#-- ROOT (required) ------------------------------------------------------------
-# (with ROOTConfig & UseROOT files from ROOT installation)
-#
-if(NOT ROOT_FOUND)
-  find_package(ROOT CONFIG REQUIRED)
-endif()
-include(${ROOT_USE_FILE})
-
 #--- Utility to defined installation lib directory -----------------------------
 if("${CMAKE_INSTALL_LIBDIR}" MATCHES "")
   include(VMCInstallLibDir)


### PR DESCRIPTION
This resolves issue pointed in https://github.com/FairRootGroup/FairRoot/pull/1123