### PR TITLE
Updated TVirtualMC interface for new features in Geant4 and clean-up:

### DIFF
--- a/source/include/TMCAutoLock.h
+++ b/source/include/TMCAutoLock.h
@@ -58,10 +58,7 @@
 // * acceptance of all terms of the Geant4 Software license.          *
 // ********************************************************************
 //
-// $Id$
-//
-// ---------------------------------------------------------------
-// GEANT 4 class header file
+// G4Autolock
 //
 // Class Description:
 //
@@ -71,100 +68,591 @@
 //
 //      #include "G4Threading.hh"
 //      #include "G4AutoLock.hh"
-//      /* somehwere */
-//      G4Mutex aMutex = G4MUTEX_INITIALIZER;
-//      /*
-//       somewhere else:
-//       The G4AutoLock instance will automatically unlock the mutex when it
-//       goes out of scope, lock and unlock method are anyway available for
-//       explicit handling of mutex lock. */
-//      G4AutoLock l(&aMutex);
-//      ProtectedCode();
-//      l.unlock(); //explicit unlock
-//      UnprotectedCode();
-//      l.lock();   //explicit lock
 //
-// Note that G4AutoLock is defined also for a sequential Geant4 build,
-// but has no effect.
+//      // defined somewhere -- static so all threads see the same mutex
+//      static G4Mutex aMutex;
+//
+//      // somewhere else:
+//      // The G4AutoLock instance will automatically unlock the mutex when it
+//      // goes out of scope. One typically defines the scope within { } if
+//      // there is thread-safe code following the auto-lock
+//
+//      {
+//          G4AutoLock l(&aMutex);
+//          ProtectedCode();
+//      }
+//
+//      UnprotectedCode();
+//
+//      // When ProtectedCode() is calling a function that also tries to lock
+//      // a normal G4AutoLock + G4Mutex will "deadlock". In other words, the
+//      // the mutex in the ProtectedCode() function will wait forever to
+//      // acquire the lock that is being held by the function that called
+//      // ProtectedCode(). In this situation, use a G4RecursiveAutoLock +
+//      // G4RecursiveMutex, e.g.
+//
+//      // defined somewhere -- static so all threads see the same mutex
+//      static G4RecursiveMutex aRecursiveMutex;
+//
+//      // this function is sometimes called directly and sometimes called
+//      // from SomeFunction_B(), which also locks the mutex
+//      void SomeFunction_A()
+//      {
+//          // when called from SomeFunction_B(), a G4Mutex + G4AutoLock will
+//          // deadlock
+//          G4RecursiveAutoLock l(&aRecursiveMutex);
+//          // do something
+//      }
+//
+//      void SomeFunction_B()
+//      {
+//
+//          {
+//              G4RecursiveAutoLock l(&aRecursiveMutex);
+//              SomeFunction_A();
+//          }
+//
+//          UnprotectedCode();
+//      }
+//
 
-// ---------------------------------------------------------------
+// --------------------------------------------------------------------
 // Author: Andrea Dotti (15 Feb 2013): First Implementation
-// ---------------------------------------------------------------
+//
+// Update: Jonathan Madsen (9 Feb 2018): Replaced custom implementation
+//      with inheritance from C++11 unique_lock, which inherits the
+//      following member functions:
+//
+//      - unique_lock(unique_lock&& other) noexcept;
+//      - explicit unique_lock(mutex_type& m);
+//      - unique_lock(mutex_type& m, std::defer_lock_t t) noexcept;
+//      - unique_lock(mutex_type& m, std::try_to_lock_t t);
+//      - unique_lock(mutex_type& m, std::adopt_lock_t t);
+//
+//      - template <typename Rep, typename Period>
+//        unique_lock(mutex_type& m,
+//                   const std::chrono::duration<Rep,Period>& timeout_duration);
+//
+//      - template<typename Clock, typename Duration>
+//        unique_lock(mutex_type& m,
+//              const std::chrono::time_point<Clock,Duration>& timeout_time);
+//
+//      - void lock();
+//      - void unlock();
+//      - bool try_lock();
+//
+//      - template <typename Rep, typename Period>
+//        bool try_lock_for(const std::chrono::duration<Rep,Period>&);
+//
+//      - template <typename Rep, typename Period>
+//        bool try_lock_until(const std::chrono::time_point<Clock,Duration>&);
+//
+//      - void swap(unique_lock& other) noexcept;
+//      - mutex_type* release() noexcept;
+//      - mutex_type* mutex() const noexcept;
+//      - bool owns_lock() const noexcept;
+//      - explicit operator bool() const noexcept;
+//      - unique_lock& operator=(unique_lock&& other);
+//
+// --------------------------------------------------------------------
+//
+// Note that G4AutoLock is defined also for a sequential Geant4 build but below
+// regarding implementation (also found in G4Threading.hh)
+//
+//
+//          NOTE ON GEANT4 SERIAL BUILDS AND MUTEX/UNIQUE_LOCK
+//          ==================================================
+//
+// G4Mutex and G4RecursiveMutex are always C++11 std::mutex types
+// however, in serial mode, using G4MUTEXLOCK and G4MUTEXUNLOCK on these
+// types has no effect -- i.e. the mutexes are not actually locked or unlocked
+//
+// Additionally, when a G4Mutex or G4RecursiveMutex is used with G4AutoLock
+// and G4RecursiveAutoLock, respectively, these classes also suppressing
+// the locking and unlocking of the mutex. Regardless of the build type,
+// G4AutoLock and G4RecursiveAutoLock inherit from std::unique_lock<std::mutex>
+// and std::unique_lock<std::recursive_mutex>, respectively. This means
+// that in situations (such as is needed by the analysis category), the
+// G4AutoLock and G4RecursiveAutoLock can be passed to functions requesting
+// a std::unique_lock. Within these functions, since std::unique_lock
+// member functions are not virtual, they will not retain the dummy locking
+// and unlocking behavior
+// --> An example of this behavior can be found below
+//
+//  Jonathan R. Madsen (February 21, 2018)
+//
+/**
+
+//============================================================================//
+
+void print_threading()
+{
+#ifdef TMCMULTITHREADED
+    std::cout << "\nUsing TMCMULTITHREADED version..." << std::endl;
+#else
+    std::cout << "\nUsing G4SERIAL version..." << std::endl;
+#endif
+}
+
+//============================================================================//
+
+typedef std::unique_lock<std::mutex> unique_lock_t;
+// functions for casting G4AutoLock to std::unique_lock to demonstrate
+// that G4AutoLock is NOT polymorphic
+void as_unique_lock(unique_lock_t* lock) { lock->lock(); }
+void as_unique_unlock(unique_lock_t* lock) { lock->unlock(); }
+
+//============================================================================//
+
+void run(const uint64_t& n)
+{
+    // sync the threads a bit
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    // get two mutexes to avoid deadlock when l32 actually locks
+    G4AutoLock l32(G4TypeMutex<int32_t>(), std::defer_lock);
+    G4AutoLock l64(G4TypeMutex<int64_t>(), std::defer_lock);
+
+    // when serial: will not execute std::unique_lock::lock() because
+    // it overrides the member function
+    l32.lock();
+    // regardless of serial or MT: will execute std::unique_lock::lock()
+    // because std::unique_lock::lock() is not virtual
+    as_unique_lock(&l64);
+
+    std::cout << "Running iteration " << n << "..." << std::endl;
+}
+
+//============================================================================//
+// execute some work
+template <typename thread_type = std::thread>
+void exec(uint64_t n)
+{
+    // get two mutexes to avoid deadlock when l32 actually locks
+    G4AutoLock l32(G4TypeMutex<int32_t>(), std::defer_lock);
+    G4AutoLock l64(G4TypeMutex<int64_t>(), std::defer_lock);
+
+    std::vector<thread_type*> threads(n, nullptr);
+    for(uint64_t i = 0; i < n; ++i)
+    {
+        threads[i] = new thread_type();
+        *(threads[i]) = std::move(thread_type(run, i));
+    }
+
+    // when serial: will not execute std::unique_lock::lock() because
+    // it overrides the member function
+    l32.lock();
+    // regardless of serial or MT: will execute std::unique_lock::lock()
+    // because std::unique_lock::lock() is not virtual
+    as_unique_lock(&l64);
+
+    std::cout << "Joining..." << std::endl;
+
+    // when serial: will not execute std::unique_lock::unlock() because
+    // it overrides the member function
+    l32.unlock();
+    // regardless of serial or MT: will execute std::unique_lock::unlock()
+    // because std::unique_lock::unlock() is not virtual
+    as_unique_unlock(&l64);
+
+    // NOTE ABOUT UNLOCKS:
+    // in MT, commenting out either
+    //      l32.unlock();
+    // or
+    //      as_unique_unlock(&l64);
+    // creates a deadlock; in serial, commenting out
+    //      as_unique_unlock(&l64);
+    // creates a deadlock but commenting out
+    //      l32.unlock();
+    // does not
+
+    // clean up and join
+    for(uint64_t i = 0; i < n; ++i)
+    {
+        threads[i]->join();
+        delete threads[i];
+    }
+    threads.clear();
+}
+
+//============================================================================//
+
+int main()
+{
+    print_threading();
+
+    uint64_t n = 30;
+    std::cout << "\nRunning with real threads...\n" << std::endl;
+    exec<std::thread>(n);
+    std::cout << "\nRunning with fake threads...\n" << std::endl;
+    exec<G4DummyThread>(n);
+
+}
+
+**/
+// --------------------------------------------------------------------
 
 #ifndef _WIN32
 #define TMCMULTITHREADED 1
 #endif
 
-#if defined(TMCMULTITHREADED)
+#include <chrono>
+#include <iostream>
+#include <mutex>
+#include <system_error>
 
-#include <pthread.h>
-typedef pthread_mutex_t TMCMutex;
-#define TMCMUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
-#define TMCMUTEXLOCK pthread_mutex_lock
-#define TMCMUTEXUNLOCK pthread_mutex_unlock
-typedef int (*TMCthread_lock)(TMCMutex *);
-typedef int (*TMCthread_unlock)(TMCMutex *);
+
+// Definitions from G4Threading.hh
+
+// Global mutex types
+using TMCMutex          = std::mutex;
+using TMCRecursiveMutex = std::recursive_mutex;
+using thread_lock =
+  int (*)(TMCMutex*);  // typedef Int (*thread_lock)(TMCMutex*);
+using thread_unlock =
+  int (*)(TMCMutex*);  // typedef int (*thread_unlock)(TMCMutex*);
+
+
+// Mutex macros
+#define TMCMUTEX_INITIALIZER                                               \
+  {}
+
+#if defined(TMCMULTITHREADED)
+// mutex macros
+#define TMCMUTEXLOCK(mutex)                                                \
+{                                                                          \
+  (mutex)->lock();                                                         \
+}
+#define TMCMUTEXUNLOCK(mutex)                                              \
+{                                                                          \
+  (mutex)->unlock();                                                       \
+}
 #else
-typedef int TMCMutex;
-int fake_mutex_lock_unlock(TMCMutex *);
-#define TMCMUTEX_INITIALIZER 1
-#define TMCMUTEXLOCK fake_mutex_lock_unlock
-#define TMCMUTEXUNLOCK fake_mutex_lock_unlock
-typedef int (*TMCthread_lock)(TMCMutex *);
-typedef int (*TMCthread_unlock)(TMCMutex *);
+// mutex macros
+#define TMCMUTEXLOCK(mutex)                                                \
+  {}
+#define TMCMUTEXUNLOCK(mutex)                                              \
+  {}
 #endif
 
-/// \brief Template classe which provides a mechanism to create a mutex and
-/// locks/unlocks it.
-///
-/// Extracted from G4AutoLock implementation for Linux
-/// Note: Note that G4TemplateAutoLock by itself is not thread-safe and
-///       cannot be shared among threads due to the locked switch
+// Note: Note that TMCTemplateAutoLock by itself is not thread-safe and
+//       cannot be shared among threads due to the locked switch
+//
+template <typename _Mutex_t>
+class TMCTemplateAutoLock : public std::unique_lock<_Mutex_t>
+{
+ public:
+  //------------------------------------------------------------------------//
+  // Some useful typedefs
+  //------------------------------------------------------------------------//
+  typedef std::unique_lock<_Mutex_t> unique_lock_t;
+  typedef TMCTemplateAutoLock<_Mutex_t> this_type;
+  typedef typename unique_lock_t::mutex_type mutex_type;
 
-template <class M, typename L, typename U>
-class TMCTemplateAutoLock {
-public:
-   TMCTemplateAutoLock(M *mtx, L l, U u) : locked(false), _m(mtx), _l(l), _u(u) { lock(); }
+ public:
+  //------------------------------------------------------------------------//
+  // STL-consistent reference form constructors
+  //------------------------------------------------------------------------//
 
-   virtual ~TMCTemplateAutoLock() { unlock(); }
+  // reference form is consistent with STL lock_guard types
+  // Locks the associated mutex by calling m.lock(). The behavior is
+  // undefined if the current thread already owns the mutex except when
+  // the mutex is recursive
+  TMCTemplateAutoLock(mutex_type& _mutex)
+    : unique_lock_t(_mutex, std::defer_lock)
+  {
+    // call termination-safe locking. if serial, this call has no effect
+    _lock_deferred();
+  }
 
-   inline void unlock()
-   {
-      if (!locked) return;
-      _u(_m);
-      locked = false;
-   }
+  // Tries to lock the associated mutex by calling
+  // m.try_lock_for(_timeout_duration). Blocks until specified
+  // _timeout_duration has elapsed or the lock is acquired, whichever comes
+  // first. May block for longer than _timeout_duration.
+  template <typename Rep, typename Period>
+  TMCTemplateAutoLock(
+    mutex_type& _mutex,
+    const std::chrono::duration<Rep, Period>& _timeout_duration)
+    : unique_lock_t(_mutex, std::defer_lock)
+  {
+    // call termination-safe locking. if serial, this call has no effect
+    _lock_deferred(_timeout_duration);
+  }
 
-   inline void lock()
-   {
-      if (locked) return;
-      _l(_m);
-      locked = true;
-   }
+  // Tries to lock the associated mutex by calling
+  // m.try_lock_until(_timeout_time). Blocks until specified _timeout_time has
+  // been reached or the lock is acquired, whichever comes first. May block
+  // for longer than until _timeout_time has been reached.
+  template <typename Clock, typename Duration>
+  TMCTemplateAutoLock(
+    mutex_type& _mutex,
+    const std::chrono::time_point<Clock, Duration>& _timeout_time)
+    : unique_lock_t(_mutex, std::defer_lock)
+  {
+    // call termination-safe locking. if serial, this call has no effect
+    _lock_deferred(_timeout_time);
+  }
 
-private:
-   // Disable copy and assignement operators
-   //
-   TMCTemplateAutoLock(const TMCTemplateAutoLock &rhs);
-   TMCTemplateAutoLock &operator=(const TMCTemplateAutoLock &rhs);
+  // Does not lock the associated mutex.
+  TMCTemplateAutoLock(mutex_type& _mutex, std::defer_lock_t _lock) noexcept
+    : unique_lock_t(_mutex, _lock)
+  {}
 
-private:
-   bool locked;
-   M *_m;
-   L _l;
-   U _u;
+#ifdef TMCMULTITHREADED
+
+  // Tries to lock the associated mutex without blocking by calling
+  // m.try_lock(). The behavior is undefined if the current thread already
+  // owns the mutex except when the mutex is recursive.
+  TMCTemplateAutoLock(mutex_type& _mutex, std::try_to_lock_t _lock)
+    : unique_lock_t(_mutex, _lock)
+  {}
+
+  // Assumes the calling thread already owns m
+  TMCTemplateAutoLock(mutex_type& _mutex, std::adopt_lock_t _lock)
+    : unique_lock_t(_mutex, _lock)
+  {}
+
+#else
+
+  // serial dummy version (initializes unique_lock but does not lock)
+  TMCTemplateAutoLock(mutex_type& _mutex, std::try_to_lock_t)
+    : unique_lock_t(_mutex, std::defer_lock)
+  {}
+
+  // serial dummy version (initializes unique_lock but does not lock)
+  TMCTemplateAutoLock(mutex_type& _mutex, std::adopt_lock_t)
+    : unique_lock_t(_mutex, std::defer_lock)
+  {}
+
+#endif  // defined(TMCMULTITHREADED)
+
+ public:
+  //------------------------------------------------------------------------//
+  // Backwards compatibility versions (constructor with pointer to mutex)
+  //------------------------------------------------------------------------//
+  TMCTemplateAutoLock(mutex_type* _mutex)
+    : unique_lock_t(*_mutex, std::defer_lock)
+  {
+    // call termination-safe locking. if serial, this call has no effect
+    _lock_deferred();
+  }
+
+  TMCTemplateAutoLock(mutex_type* _mutex, std::defer_lock_t _lock) noexcept
+    : unique_lock_t(*_mutex, _lock)
+  {}
+
+#if defined(TMCMULTITHREADED)
+
+  TMCTemplateAutoLock(mutex_type* _mutex, std::try_to_lock_t _lock)
+    : unique_lock_t(*_mutex, _lock)
+  {}
+
+  TMCTemplateAutoLock(mutex_type* _mutex, std::adopt_lock_t _lock)
+    : unique_lock_t(*_mutex, _lock)
+  {}
+
+#else  // NOT defined(TMCMULTITHREADED) -- i.e. serial
+
+  TMCTemplateAutoLock(mutex_type* _mutex, std::try_to_lock_t)
+    : unique_lock_t(*_mutex, std::defer_lock)
+  {}
+
+  TMCTemplateAutoLock(mutex_type* _mutex, std::adopt_lock_t)
+    : unique_lock_t(*_mutex, std::defer_lock)
+  {}
+
+#endif  // defined(TMCMULTITHREADED)
+
+ public:
+  //------------------------------------------------------------------------//
+  // Non-constructor overloads
+  //------------------------------------------------------------------------//
+
+#if defined(TMCMULTITHREADED)
+
+  // overload nothing
+
+#else  // NOT defined(TMCMULTITHREADED) -- i.e. serial
+
+  // override unique lock member functions to keep from locking/unlocking
+  // but does not override in polymorphic usage
+  void lock() {}
+  void unlock() {}
+  bool try_lock() { return true; }
+
+  template <typename Rep, typename Period>
+  bool try_lock_for(const std::chrono::duration<Rep, Period>&)
+  {
+    return true;
+  }
+
+  template <typename Clock, typename Duration>
+  bool try_lock_until(const std::chrono::time_point<Clock, Duration>&)
+  {
+    return true;
+  }
+
+  void swap(this_type& other) noexcept { std::swap(*this, other); }
+  bool owns_lock() const noexcept { return false; }
+
+  // no need to overload
+  // explicit operator bool() const noexcept;
+  // this_type& operator=(this_type&& other);
+  // mutex_type* release() noexcept;
+  // mutex_type* mutex() const noexcept;
+
+#endif  // defined(TMCMULTITHREADED)
+
+ private:
+// helpful macros
+#define _is_stand_mutex(_Tp) (std::is_same<_Tp, TMCMutex>::value)
+#define _is_recur_mutex(_Tp) (std::is_same<_Tp, TMCRecursiveMutex>::value)
+#define _is_other_mutex(_Tp) (!_is_stand_mutex(_Tp) && !_is_recur_mutex(_Tp))
+
+  template <typename _Tp                                             = _Mutex_t,
+            typename std::enable_if<_is_stand_mutex(_Tp), int>::type = 0>
+  std::string GetTypeString()
+  {
+    return "TMCAutoLock<TMCMutex>";
+  }
+
+  template <typename _Tp                                             = _Mutex_t,
+            typename std::enable_if<_is_recur_mutex(_Tp), int>::type = 0>
+  std::string GetTypeString()
+  {
+    return "TMCAutoLock<TMCRecursiveMutex>";
+  }
+
+  template <typename _Tp                                             = _Mutex_t,
+            typename std::enable_if<_is_other_mutex(_Tp), int>::type = 0>
+  std::string GetTypeString()
+  {
+    return "TMCAutoLock<UNKNOWN_MUTEX>";
+  }
+
+// pollution is bad
+#undef _is_stand_mutex
+#undef _is_recur_mutex
+#undef _is_other_mutex
+
+  // used in _lock_deferred chrono variants to avoid ununsed-variable warning
+  template <typename _Tp>
+  void suppress_unused_variable(const _Tp&)
+  {}
+
+  //========================================================================//
+  // NOTE on _lock_deferred(...) variants:
+  //      a system_error in lock means that the mutex is unavailable
+  //      we want to throw the error that comes from locking an unavailable
+  //      mutex so that we know there is a memory leak
+  //      if the mutex is valid, this will hold until the other thread
+  //      finishes
+
+  // sometimes certain destructors use locks, this isn't an issue unless
+  // the object is leaked. When this occurs, the application finalization
+  // (i.e. the real or implied "return 0" part of main) will call destructors
+  // on Geant4 object after some static mutex variables are deleted, leading
+  // to the error code (typically on Clang compilers):
+  //      libc++abi.dylib: terminating with uncaught exception of type
+  //      std::__1::system_error: mutex lock failed: Invalid argument
+  // this function protects against this failure until such a time that
+  // these issues have been resolved
+
+  //========================================================================//
+  // standard locking
+  inline void _lock_deferred()
+  {
+#if defined(TMCMULTITHREADED)
+    try
+    {
+      this->unique_lock_t::lock();
+    } catch(std::system_error& e)
+    {
+      PrintLockErrorMessage(e);
+    }
+#endif
+  }
+
+  //========================================================================//
+  // Tries to lock the associated mutex by calling
+  // m.try_lock_for(_timeout_duration). Blocks until specified
+  // _timeout_duration has elapsed or the lock is acquired, whichever comes
+  // first. May block for longer than _timeout_duration.
+  template <typename Rep, typename Period>
+  void _lock_deferred(
+    const std::chrono::duration<Rep, Period>& _timeout_duration)
+  {
+#if defined(TMCMULTITHREADED)
+    try
+    {
+      this->unique_lock_t::try_lock_for(_timeout_duration);
+    } catch(std::system_error& e)
+    {
+      PrintLockErrorMessage(e);
+    }
+#else
+    suppress_unused_variable(_timeout_duration);
+#endif
+  }
+
+  //========================================================================//
+  // Tries to lock the associated mutex by calling
+  // m.try_lock_until(_timeout_time). Blocks until specified _timeout_time has
+  // been reached or the lock is acquired, whichever comes first. May block
+  // for longer than until _timeout_time has been reached.
+  template <typename Clock, typename Duration>
+  void _lock_deferred(
+    const std::chrono::time_point<Clock, Duration>& _timeout_time)
+  {
+#if defined(TMCMULTITHREADED)
+    try
+    {
+      this->unique_lock_t::try_lock_until(_timeout_time);
+    } catch(std::system_error& e)
+    {
+      PrintLockErrorMessage(e);
+    }
+#else
+    suppress_unused_variable(_timeout_time);
+#endif
+  }
+
+  //========================================================================//
+  // the message for what mutex lock fails due to deleted static mutex
+  // at termination
+  void PrintLockErrorMessage(std::system_error& e)
+  {
+    // use std::cout/std::endl to avoid include dependencies
+    using std::cout;
+    using std::endl;
+    // the error that comes from locking an unavailable mutex
+    cout << "Non-critical error: mutex lock failure in "
+         << GetTypeString<mutex_type>() << ". "
+         << "If the app is terminating, Geant4 failed to "
+         << "delete an allocated resource and a Geant4 destructor is "
+         << "being called after the statics were destroyed. \n\t--> "
+         << "Exception: [code: " << e.code() << "] caught: " << e.what()
+         << endl;
+    // suppress_unused_variable(e);
+  }
 };
 
-/// \brief Realization of TMCTemplateAutoLock with TMCMutex
-///
-/// Extracted from G4AutoLock implementation for Linux
+// -------------------------------------------------------------------------- //
+//
+//      Use the non-template types below:
+//          - TMCAutoLock with TMCMutex
+//          - TMCRecursiveAutoLock with TMCRecursiveMutex
+//
+// -------------------------------------------------------------------------- //
 
-struct TMCImpMutexAutoLock : public TMCTemplateAutoLock<TMCMutex, TMCthread_lock, TMCthread_unlock> {
-   TMCImpMutexAutoLock(TMCMutex *mtx)
-      : TMCTemplateAutoLock<TMCMutex, TMCthread_lock, TMCthread_unlock>(mtx, &TMCMUTEXLOCK, &TMCMUTEXUNLOCK)
-   {
-   }
-};
-typedef TMCImpMutexAutoLock TMCAutoLock;
+using TMCAutoLock          = TMCTemplateAutoLock<TMCMutex>;
+using TMCRecursiveAutoLock = TMCTemplateAutoLock<TMCRecursiveMutex>;
+
+// provide abbriviated type if another mutex type is desired to be used
+// aside from above
+template <typename _Tp>
+using TMCTAutoLock = TMCTemplateAutoLock<_Tp>;
+
+
 
 #endif // TMCAUTOLOCK_HH

--- a/source/include/TMCOptical.h
+++ b/source/include/TMCOptical.h
@@ -27,28 +27,79 @@
 /// Optical surface models
 enum EMCOpSurfaceModel
 {
-   kGlisur,                      ///< original GEANT3 model
-   kUnified                      ///< UNIFIED model
+   kGlisur,                ///< original GEANT3 model
+   kUnified,               ///< UNIFIED model
+   kLUT,                   ///< Look-Up-Table model (LBNL model)
+   kDAVIS,                 ///< DAVIS model
+   kdichroic               ///< dichroic filter
 };
 
 /// Optical surface types
 enum EMCOpSurfaceType
 {
-   kDielectric_metal,            ///< dielectric-metal interface
-   kDielectric_dielectric,       ///< dielectric-dielectric interface
-   kFirsov,                      ///< for Firsov Process
-   kXray                         ///< for x-ray mirror process
+   kDielectric_metal,      ///< dielectric-metal interface
+   kDielectric_dielectric, ///< dielectric-dielectric interface
+   kDielectric_LUT,        ///< dielectric-Look-Up-Table interface
+   kDielectric_LUTDAVIS,   ///< dielectric-Look-Up-Table DAVIS interface
+   kDielectric_dichroic,   ///< dichroic filter interface
+   kFirsov,                ///< for Firsov Process
+   kXray                   ///< for x-ray mirror process
 };
 
 /// Optical surface finish types
 enum EMCOpSurfaceFinish
 {
-   kPolished,                    ///< smooth perfectly polished surface
-   kPolishedfrontpainted,        ///< smooth top-layer (front) paint
-   kPolishedbackpainted,         ///< same is 'polished' but with a back-paint
-   kGround,                      ///< rough surface
-   kGroundfrontpainted,          ///< rough top-layer (front) paint
-   kGroundbackpainted            ///< same as 'ground' but with a back-paint
+   kPolished,              ///<  smooth perfectly polished surface
+   kPolishedfrontpainted,  ///<  smooth top-layer (front) paint
+   kPolishedbackpainted,   ///<  same is 'polished' but with a back-paint
+
+   kGround,                ///<  rough surface
+   kGroundfrontpainted,    ///<  rough top-layer (front) paint
+   kGroundbackpainted,     ///<  same as 'ground' but with a back-paint
+
+   // for LBNL LUT model
+   kPolishedlumirrorair,   ///<  mechanically polished surface, with lumirror
+   kPolishedlumirrorglue,  ///<  mechanically polished surface, with lumirror &
+                           ///   meltmount
+   kPolishedair,           ///<  mechanically polished surface
+   kPolishedteflonair,     ///<  mechanically polished surface, with teflon
+   kPolishedtioair,        ///<  mechanically polished surface, with tio paint
+   kPolishedtyvekair,      ///<  mechanically polished surface, with tyvek
+   kPolishedvm2000air,     ///<  mechanically polished surface, with esr film
+   kPolishedvm2000glue,    ///<  mechanically polished surface, with esr film &
+                           ///   meltmount
+
+   kEtchedlumirrorair,     ///<  chemically etched surface, with lumirror
+   kEtchedlumirrorglue,    ///<  chemically etched surface, with lumirror & meltmount
+   kEtchedair,             ///<  chemically etched surface
+   kEtchedteflonair,       ///<  chemically etched surface, with teflon
+   kEtchedtioair,          ///<  chemically etched surface, with tio paint
+   kEtchedtyvekair,        ///<  chemically etched surface, with tyvek
+   kEtchedvm2000air,       ///<  chemically etched surface, with esr film
+   kEtchedvm2000glue,      ///<  chemically etched surface, with esr film & meltmount
+
+   kGroundlumirrorair,     ///<  rough-cut surface, with lumirror
+   kGroundlumirrorglue,    ///<  rough-cut surface, with lumirror & meltmount
+   kGroundair,             ///<  rough-cut surface
+   kGroundteflonair,       ///<  rough-cut surface, with teflon
+   kGroundtioair,          ///<  rough-cut surface, with tio paint
+   kGroundtyvekair,        ///<  rough-cut surface, with tyvek
+   kGroundvm2000air,       ///<  rough-cut surface, with esr film
+   kGroundvm2000glue,      ///<  rough-cut surface, with esr film & meltmount
+
+   // for DAVIS model
+   kRough_LUT,             ///<  rough surface
+   kRoughTeflon_LUT,       ///<  rough surface wrapped in Teflon tape
+   kRoughESR_LUT,          ///<  rough surface wrapped with ESR
+   kRoughESRGrease_LUT,    ///<  rough surface wrapped with ESR
+                           ///   and coupled with optical grease
+   kPolished_LUT,          ///   polished surface
+   kPolishedTeflon_LUT,    ///<  polished surface wrapped in Teflon tape
+   kPolishedESR_LUT,       ///<  polished surface wrapped with ESR
+   kPolishedESRGrease_LUT, ///<  polished surface wrapped with ESR
+                           ///   and coupled with optical grease
+   kDetector_LUT           ///   polished surface with optical grease
+
 };
 
 #endif //ROOT_TMCOPtical

--- a/source/include/TMCtls.h
+++ b/source/include/TMCtls.h
@@ -51,44 +51,44 @@
 // a build option
 #define VMC_MULTITHREADED 1
 
-#if ( defined (VMC_MULTITHREADED) )
-
-#if (defined(__MACH__) && defined(__clang__) && defined(__x86_64__)) || (defined(__linux__) && defined(__clang__))
-#if (__has_feature(cxx_thread_local))
-#define TMCThreadLocalStatic static thread_local
-#define TMCThreadLocal thread_local
-#else
-#define TMCThreadLocalStatic static __thread
-#define TMCThreadLocal __thread
-#endif
-
-#elif ((defined(__linux__) || defined(__MACH__)) && !defined(__INTEL_COMPILER) && defined(__GNUC__) && \
-       (__GNUC__ >= 4 && __GNUC_MINOR__ < 9))
-#define TMCThreadLocalStatic static __thread
-#define TMCThreadLocal thread_local
-
-#elif ((defined(__linux__) || defined(__MACH__)) && !defined(__INTEL_COMPILER) && defined(__GNUC__) && \
-          (__GNUC__ >= 4 && __GNUC_MINOR__ >= 9) ||                                                    \
-       __GNUC__ >= 5)
-#define TMCThreadLocalStatic static thread_local
-#define TMCThreadLocal thread_local
-
-#elif ((defined(__linux__) || defined(__MACH__)) && defined(__INTEL_COMPILER))
-#if (__INTEL_COMPILER >= 1500)
-#define TMCThreadLocalStatic static thread_local
-#define TMCThreadLocal thread_local
-#else
-#define TMCThreadLocalStatic static __thread
-#define TMCThreadLocal __thread
-#endif
-#else
-//#  error "No Thread Local Storage (TLS) technology supported for this platform. Use sequential build !"
-#define TMCThreadLocalStatic static
-#define TMCThreadLocal
-#endif
-#else
-#define TMCThreadLocalStatic static
-#define TMCThreadLocal
-#endif
+#  if defined(VMC_MULTITHREADED)
+#    if(defined(__MACH__) && defined(__clang__)) ||                            \
+      (defined(__linux__) && defined(__clang__))
+#      define TMCThreadLocalStatic static thread_local
+#      define TMCThreadLocal thread_local
+#    elif((defined(__linux__) || defined(__MACH__)) &&                         \
+          !defined(__INTEL_COMPILER) && defined(__GNUC__) &&                   \
+          (__GNUC__ >= 4 && __GNUC_MINOR__ < 9))
+#      define TMCThreadLocalStatic static __thread
+#      define TMCThreadLocal thread_local
+#    elif((defined(__linux__) || defined(__MACH__)) &&                         \
+            !defined(__INTEL_COMPILER) && defined(__GNUC__) &&                 \
+            (__GNUC__ >= 4 && __GNUC_MINOR__ >= 9) ||                          \
+          __GNUC__ >= 5)
+#      define TMCThreadLocalStatic static thread_local
+#      define TMCThreadLocal thread_local
+#    elif((defined(__linux__) || defined(__MACH__)) &&                         \
+          defined(__INTEL_COMPILER))
+#      if __INTEL_COMPILER >= 1500
+#        define TMCThreadLocalStatic static thread_local
+#        define TMCThreadLocal thread_local
+#      else
+#        define TMCThreadLocalStatic static __thread
+#        define TMCThreadLocal __thread
+#      endif
+#    elif defined(_AIX)
+#      define TMCThreadLocalStatic static thread_local
+#      define TMCThreadLocal thread_local
+#    elif defined(WIN32)
+#      define TMCThreadLocalStatic static thread_local
+#      define TMCThreadLocal thread_local
+#    else
+#      error                                                                   \
+        "No Thread Local Storage (TLS) technology supported for this platform. Use sequential build !"
+#    endif
+#  else
+#    define TMCThreadLocalStatic static
+#    define TMCThreadLocal
+#  endif
 
 #endif //ROOT_TMCtls

--- a/source/include/TVirtualMC.h
+++ b/source/include/TVirtualMC.h
@@ -267,12 +267,14 @@ public:
    ///                     - metals    : absorption fraction (0<=x<=1)
    /// - effic       Detection efficiency for UV photons
    /// - rindex      Refraction index (if=0 metal)
+   /// - aspline     Enable spline interpolation of the absco data (Geant4 only)
+   /// - rspline     Enable spline interpolation of the rindex data (Geant4 only)
    virtual void
-   SetCerenkov(Int_t itmed, Int_t npckov, Float_t *ppckov, Float_t *absco, Float_t *effic, Float_t *rindex) = 0;
+   SetCerenkov(Int_t itmed, Int_t npckov, Float_t *ppckov, Float_t *absco, Float_t *effic, Float_t *rindex, Bool_t aspline = false, Bool_t rspline = false) = 0;
 
    /// The same as previous but in double precision
    virtual void
-   SetCerenkov(Int_t itmed, Int_t npckov, Double_t *ppckov, Double_t *absco, Double_t *effic, Double_t *rindex) = 0;
+   SetCerenkov(Int_t itmed, Int_t npckov, Double_t *ppckov, Double_t *absco, Double_t *effic, Double_t *rindex, Bool_t aspline = false, Bool_t rspline = false) = 0;
 
    //
    // functions for definition of surfaces
@@ -314,9 +316,11 @@ public:
    /// - np            number of bins of the table
    /// - pp            value of photon momentum (in GeV)
    /// - values        property values
+   /// - createNewKey  enable user defined property
+   /// - spline        enable spline interpolation of the data
    /// (Geant4 only)
    virtual void
-   SetMaterialProperty(Int_t itmed, const char *propertyName, Int_t np, Double_t *pp, Double_t *values) = 0;
+   SetMaterialProperty(Int_t itmed, const char *propertyName, Int_t np, Double_t *pp, Double_t *values, Bool_t createNewKey = false, Bool_t spline = false) = 0;
 
    /// Define material property via a value
    /// - itmed         tracking medium id
@@ -331,9 +335,11 @@ public:
    /// - np            number of bins of the table
    /// - pp            value of photon momentum (in GeV)
    /// - values        property values
+   /// - createNewKey  enable user defined property
+   /// - spline        enable spline interpolation of the data
    /// (Geant4 only)
    virtual void
-   SetMaterialProperty(const char *surfaceName, const char *propertyName, Int_t np, Double_t *pp, Double_t *values) = 0;
+   SetMaterialProperty(const char *surfaceName, const char *propertyName, Int_t np, Double_t *pp, Double_t *values, Bool_t createNewKey = false, Bool_t spline = false) = 0;
 
    //
    // functions for access to geometry

--- a/source/include/TVirtualMC.h
+++ b/source/include/TVirtualMC.h
@@ -427,16 +427,16 @@ public:
    /// Set a sensitive detector to a volume
    /// - volName - the volume name
    /// - sd - the user sensitive detector
-   virtual void SetSensitiveDetector(const TString &volName, TVirtualMCSensitiveDetector *sd);
+   virtual void SetSensitiveDetector(const TString &volName, TVirtualMCSensitiveDetector *sd) = 0;
 
    /// Get a sensitive detector of a volume
    /// - volName - the volume name
-   virtual TVirtualMCSensitiveDetector *GetSensitiveDetector(const TString &volName) const;
+   virtual TVirtualMCSensitiveDetector *GetSensitiveDetector(const TString &volName) const = 0;
 
    /// The scoring option:
    /// if true, scoring is performed only via user defined sensitive detectors and
    /// MCApplication::Stepping is not called
-   virtual void SetExclusiveSDScoring(Bool_t exclusiveSDScoring);
+   virtual void SetExclusiveSDScoring(Bool_t exclusiveSDScoring) = 0;
 
    //
    // ------------------------------------------------
@@ -713,19 +713,19 @@ public:
    virtual Double_t Edep() const = 0;
 
    /// Return the non-ionising energy lost (NIEL) in the current step
-   virtual Double_t NIELEdep() const;
+   virtual Double_t NIELEdep() const = 0;
 
    /// Return the current step number
-   virtual Int_t StepNumber() const;
+   virtual Int_t StepNumber() const = 0;
 
    /// Get the current weight
-   virtual Double_t TrackWeight() const;
+   virtual Double_t TrackWeight() const = 0;
 
    /// Get the current polarization
-   virtual void TrackPolarization(Double_t &polX, Double_t &polY, Double_t &polZ) const;
+   virtual void TrackPolarization(Double_t &polX, Double_t &polY, Double_t &polZ) const = 0;
 
    /// Get the current polarization
-   virtual void TrackPolarization(TVector3 &pol) const;
+   virtual void TrackPolarization(TVector3 &pol) const = 0;
 
    //
    // get methods
@@ -814,10 +814,10 @@ public:
    virtual void BuildPhysics() = 0;
 
    /// Process one event
-   virtual void ProcessEvent(Int_t eventId);
+   virtual void ProcessEvent() = 0;
 
-   /// Process one event (backward-compatibility)
-   virtual void ProcessEvent();
+   /// Process one event with given eventIs
+   virtual void ProcessEvent(Int_t eventId);
 
    /// Process one  run and return true if run has finished successfully,
    /// return false in other cases (run aborted by user)
@@ -892,11 +892,11 @@ private:
    /// Further, when tracks are popped from the TVirtualMCStack it must be
    /// checked whether these are new tracks or whether they have been
    /// transported up to their current point.
-   virtual void ProcessEvent(Int_t eventId, Bool_t isInterruptible);
+   virtual void ProcessEvent(Int_t eventId, Bool_t isInterruptible) = 0;
 
    /// That triggers stopping the transport of the current track without dispatching
    /// to common routines like TVirtualMCApplication::PostTrack() etc.
-   virtual void InterruptTrack();
+   virtual void InterruptTrack() = 0;
 
    // Private, no copying.
    TVirtualMC(const TVirtualMC &mc);
@@ -913,12 +913,12 @@ private:
 #endif
 
 private:
-   Int_t fId;                      //!< Unique identification of this VMC
-                                   // (don't use TObject::SetUniqueId since this
-                                   // is used to uniquely identify TObjects in
-                                   // in general)
-                                   // An ID is given by the running TVirtualMCApp
-                                   // and not by the user.
+   /// Unique identification of this VMC.
+   /// Don't use TObject::SetUniqueId() since this is used to uniquely identify 
+   //  TObjects in in general.
+   /// An ID is given by the running TVirtualMCApp and not by the user.
+   Int_t fId; 
+
    TVirtualMCStack *fStack;        //!< Particles stack
    TMCManagerStack *fManagerStack; //!< Stack handled by the TMCManager
    TVirtualMCDecayer *fDecayer;    //!< External decayer
@@ -927,45 +927,6 @@ private:
 
    ClassDef(TVirtualMC, 1) // Interface to Monte Carlo
 };
-
-// inline functions (with temorary implementation)
-
-inline void TVirtualMC::SetSensitiveDetector(const TString & /*volName*/, TVirtualMCSensitiveDetector * /*sd*/)
-{
-   /// Set a sensitive detector to a volume
-   /// - volName - the volume name
-   /// - sd - the user sensitive detector
-
-   Warning("SetSensitiveDetector(...)", "New function - not yet implemented.");
-}
-
-inline TVirtualMCSensitiveDetector *TVirtualMC::GetSensitiveDetector(const TString & /*volName*/) const
-{
-   /// Get a sensitive detector of a volume
-   /// - volName - the volume name
-
-   Warning("GetSensitiveDetector()", "New function - not yet implemented.");
-
-   return 0;
-}
-
-inline void TVirtualMC::SetExclusiveSDScoring(Bool_t /*exclusiveSDScoring*/)
-{
-   /// The scoring option:
-   /// if true, scoring is performed only via user defined sensitive detectors and
-   /// MCApplication::Stepping is not called
-
-   Warning("SetExclusiveSDScoring(...)", "New function - not yet implemented.");
-}
-
-inline Double_t TVirtualMC::NIELEdep() const
-{
-   /// Return the non-ionising energy lost (NIEL) in the current step
-
-   Warning("NIELEdep()", "New function - not yet implemented.");
-
-   return 0.;
-}
 
 #define gMC (TVirtualMC::GetMC())
 

--- a/source/include/TVirtualMCApplication.h
+++ b/source/include/TVirtualMCApplication.h
@@ -126,16 +126,6 @@ public:
    /// Clone MC application on worker
    virtual TVirtualMCApplication *CloneForWorker() const { return 0; }
 
-   /// Const Initialize MC application on worker  - now deprecated
-   /// Use new non-const InitOnWorker()  instead
-   virtual void InitForWorker() const {}
-   /// Const Define actions at the beginning of the worker run if needed - now deprecated
-   /// Use new non-const BeginRunOnWorker() instead
-   virtual void BeginWorkerRun() const {}
-   /// Const Define actions at the end of the worker run if needed - now deprecated
-   /// Use new non-const FinishRunOnWorker() instead
-   virtual void FinishWorkerRun() const {}
-
    /// Initialize MC application on worker
    virtual void InitOnWorker() {}
    /// Define actions at the beginning of the worker run if needed

--- a/source/src/TVirtualMC.cxx
+++ b/source/src/TVirtualMC.cxx
@@ -117,6 +117,16 @@ TVirtualMC *TVirtualMC::GetMC()
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
+/// Process one event with given eventId
+///
+
+void TVirtualMC::ProcessEvent(Int_t eventId)
+{
+   ProcessEvent(eventId, kFALSE);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
 /// Set particles stack.
 ///
 
@@ -158,74 +168,6 @@ void TVirtualMC::SetMagField(TVirtualMagField *field)
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// Process one event (backwards compatibility)
-///
-
-void TVirtualMC::ProcessEvent()
-{
-   Warning("ProcessEvent", "Not implemented.");
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// Process one event (backwards compatibility)
-///
-
-void TVirtualMC::ProcessEvent(Int_t eventId)
-{
-   ProcessEvent(eventId, kFALSE);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// Return the current step number
-///
-
-Int_t TVirtualMC::StepNumber() const
-{
-   Warning("StepNumber", "Not implemented.");
-   return 0;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// Get the current weight
-///
-
-Double_t TVirtualMC::TrackWeight() const
-{
-   Warning("Weight", "Not implemented.");
-   return 1.;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// Get the current polarization
-///
-
-void TVirtualMC::TrackPolarization(Double_t &polX, Double_t &polY, Double_t &polZ) const
-{
-   Warning("Polarization", "Not implemented.");
-   polX = 0.;
-   polY = 0.;
-   polZ = 0.;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// Get the current polarization
-///
-
-void TVirtualMC::TrackPolarization(TVector3 &pol) const
-{
-   Warning("Polarization", "Not implemented.");
-   pol[0] = 0.;
-   pol[1] = 0.;
-   pol[2] = 0.;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
 /// Set the VMC id
 ///
 
@@ -241,30 +183,4 @@ void TVirtualMC::SetId(UInt_t id)
 void TVirtualMC::SetManagerStack(TMCManagerStack *stack)
 {
    fManagerStack = stack;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// An interruptible event can be paused and resumed at any time. It must not
-/// call TVirtualMCApplication::BeginEvent() and ::FinishEvent()
-/// Further, when tracks are popped from the TVirtualMCStack it must be
-/// checked whether these are new tracks or whether they have been
-/// transported up to their current point.
-///
-
-void TVirtualMC::ProcessEvent(Int_t eventId, Bool_t isInterruptible)
-{
-   const char *interruptibleText = isInterruptible ? "interruptible" : "non-interruptible";
-   Warning("ProcessInterruptibleEvent", "Process %s event %i. Not implemented.", interruptibleText, eventId);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// That triggers stopping the transport of the current track without dispatching
-/// to common routines like TVirtualMCApplication::PostTrack() etc.
-///
-
-void TVirtualMC::InterruptTrack()
-{
-   Warning("InterruptTrack", "Not implemented.");
 }


### PR DESCRIPTION
- Extended methods for setting optical material properties
  - Extended TVirtualMC functions SetCerenkov() and SetMaterialProperty() to allow enabling of spline interpolation of the data and user properties
  - Extended Optical surface models, types and finish type enums to cover all values defined in Geant4 11.0

- Removed deprecated features from TVirtualMC and TVirtualMCApplication:
  - Make the TVirtualMC interface function =0 and removed the default implementation
  - Removed deprecated TVirtualMCApplication functions for MT:
    - virtual void InitForWorker() const;
    - virtual void BeginWorkerRun() const;
    - virtual void FinishWorkerRun() const;
    The non-constant functions should be used instead;
    - virtual void InitOnWorker();
    - virtual void BeginRunOnWorker();
    - virtual void FinishRunOnWorker();
    The old function calls will be removed in Geant4 VMC version > 5.4

- Updated TMCAutoLock.h, TMCtls.h
  - according to changes in Geant4 11.0
