### PR TITLE
Added TMCRootManager class previously provided in geant4_vmc

### DIFF
--- a/cmake/VMCRequiredPackages.cmake
+++ b/cmake/VMCRequiredPackages.cmake
@@ -15,7 +15,7 @@
 #message(STATUS Processing Geant4VMCRequiredPackages)
 
 #-- ROOT (required) ------------------------------------------------------------
-find_package(ROOT CONFIG COMPONENTS Geom EG REQUIRED)
+find_package(ROOT CONFIG REQUIRED COMPONENTS Geom EG REQUIRED)
 
 # Cannot mix VMC standalone and vmc in ROOT(deprecated)
 if(ROOT_vmc_FOUND)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -74,7 +74,7 @@ file(GLOB sources ${PROJECT_SOURCE_DIR}/source/src/*.cxx)
 file(GLOB headers ${PROJECT_SOURCE_DIR}/source/include/*.h)
 
 #---Add library-----------------------------------------------------------------
-set(ROOT_DEPS ROOT::Core ROOT::Physics ROOT::Geom ROOT::EG)
+set(ROOT_DEPS ROOT::Core ROOT::RIO ROOT::Tree ROOT::Physics ROOT::Geom ROOT::EG)
 add_library(${library_name} ${sources} ${root_dict} ${headers})
 target_link_libraries(${library_name} ${ROOT_DEPS})
 set_target_properties(${library_name} PROPERTIES INTERFACE_LINK_LIBRARIES "${ROOT_DEPS}")

--- a/source/include/TMCRootManager.h
+++ b/source/include/TMCRootManager.h
@@ -1,0 +1,95 @@
+#ifndef ROOT_TMCRootManager
+#define ROOT_TMCRootManager
+
+//------------------------------------------------
+// The Geant4 Virtual Monte Carlo package
+// Copyright (C) 2013 - 2018 Ivana Hrivnacova
+// All rights reserved.
+//
+// For the licensing terms see geant4_vmc/LICENSE.
+// Contact: root-vmc@cern.ch
+//-------------------------------------------------
+
+/// \file TMCRootManager.h
+/// \brief Definition of the TMCRootManager class
+///
+/// \author I. Hrivnacova; IPN Orsay
+
+#include "TMCtls.h"
+#include <Rtypes.h>
+
+class TParticle;
+class TFile;
+class TTree;
+
+/// \brief The Root IO manager for VMC examples for both sequential and
+/// multi-threaded applications.
+///
+/// It facilitates use of ROOT IO in VMC examples and also handles necessary
+/// locking in multi-threaded applications.
+
+class TMCRootManager
+{
+ public:
+  /// Root file mode
+  enum FileMode
+  {
+    kRead, // Read mode
+    kWrite // Write mode
+  };
+
+ public:
+  // static access method
+  static TMCRootManager* Instance();
+
+  // static method for activating debug mode
+  static void SetDebug(Bool_t debug);
+  static Bool_t GetDebug();
+
+  TMCRootManager(
+    const char* projectName, FileMode fileMode = kWrite, Int_t threadRank = -1);
+  virtual ~TMCRootManager();
+
+  // methods
+  void Register(const char* name, const char* className, void* objAddress);
+  void Register(
+    const char* name, const char* className, const void* objAddress);
+  void Fill();
+  void WriteAll();
+  void Close();
+  void WriteAndClose();
+  void ReadEvent(Int_t i);
+
+ private:
+  // not implemented
+  TMCRootManager(const TMCRootManager& rhs);
+  TMCRootManager& operator=(const TMCRootManager& rhs);
+
+  // global static data members
+  static Int_t fgCounter; // The counter of instances
+  // static data members
+  static Bool_t fgDebug; // Option to activate debug printings
+
+#if !defined(__CINT__)
+  static TMCThreadLocal TMCRootManager* fgInstance; // singleton instance
+#else
+  static TMCRootManager* fgInstance; // singleton instance
+#endif
+
+  // Methods
+  void OpenFile(const char* projectName, FileMode fileMode, Int_t threadRank);
+
+  // data members
+  Int_t fId;        // This manager ID
+  TFile* fFile;     // Root output file
+  TTree* fTree;     // Root output tree
+  Bool_t fIsClosed; // Info whether its file was closed
+};
+
+// inline functions
+
+inline void TMCRootManager::SetDebug(Bool_t debug) { fgDebug = debug; }
+
+inline Bool_t TMCRootManager::GetDebug() { return fgDebug; }
+
+#endif // ROOT_TMCRootManager

--- a/source/src/TMCRootManager.cxx
+++ b/source/src/TMCRootManager.cxx
@@ -1,0 +1,229 @@
+//------------------------------------------------
+// The Geant4 Virtual Monte Carlo package
+// Copyright (C) 2013 - 2018 Ivana Hrivnacova
+// All rights reserved.
+//
+// For the licensing terms see geant4_vmc/LICENSE.
+// Contact: root-vmc@cern.ch
+//-------------------------------------------------
+
+/// \file TMCRootManager.cxx
+/// \brief Implementation of the TMCRootManager class
+///
+/// \author I. Hrivnacova; IPN Orsay
+
+#include "TMCRootManager.h"
+#include "Riostream.h"
+#include "TError.h"
+#include "TFile.h"
+#include "TMCAutoLock.h"
+#include "TThread.h"
+#include "TTree.h"
+
+#include <cstdio>
+
+namespace
+{
+// Define mutexes per operation which modify shared data
+TMCMutex createMutex = TMCMUTEX_INITIALIZER;
+TMCMutex deleteMutex = TMCMUTEX_INITIALIZER;
+} // namespace
+
+//
+// static data, methods
+//
+
+Int_t TMCRootManager::fgCounter = 0;
+Bool_t TMCRootManager::fgDebug = false;
+TMCThreadLocal TMCRootManager* TMCRootManager::fgInstance = 0;
+
+//_____________________________________________________________________________
+TMCRootManager* TMCRootManager::Instance()
+{
+  /// \return The singleton instance.
+
+  return fgInstance;
+}
+
+//
+// ctors, dtor
+//
+
+//_____________________________________________________________________________
+TMCRootManager::TMCRootManager(
+  const char* projectName, TMCRootManager::FileMode fileMode, Int_t threadRank)
+  : fFile(0), fTree(0), fIsClosed(false)
+{
+  /// Standard constructor
+  /// \param projectName  The project name (passed as the Root tree name)
+  /// \param fileMode     Option for opening Root file (read or write mode)
+  /// \param threadRank   The thread Id (-1 when sequential mode)
+
+  if (fgDebug) printf("TMCRootManager::TMCRootManager %p \n", this);
+
+  // lock mutex
+  TMCAutoLock lk(&createMutex);
+
+  // Set Id
+  fId = fgCounter;
+
+  // Increment counter
+  ++fgCounter;
+
+  // singleton instance
+  if (fgInstance) {
+    Fatal("TMCRootManager", "Attempt to create two instances of singleton.");
+    return;
+  }
+
+  fgInstance = this;
+
+  // open file and create a tree
+  OpenFile(projectName, fileMode, threadRank);
+
+  // unlock mutex
+  lk.unlock();
+
+  if (fgDebug) printf("Done TMCRootManagerMT::TMCRootManagerMT %p \n", this);
+}
+
+//_____________________________________________________________________________
+TMCRootManager::~TMCRootManager()
+{
+  /// Destructor
+
+  if (fgDebug) printf("TMCRootManager::~TMCRootManager %p \n", this);
+
+  // lock mutex
+  TMCAutoLock lk(&deleteMutex);
+
+  if (fFile && !fIsClosed) fFile->Close();
+  delete fFile;
+
+  --fgCounter;
+
+  // unlock mutex
+  lk.unlock();
+
+  if (fgDebug) printf("Done TMCRootManager::~TMCRootManager %p \n", this);
+}
+
+//
+// privatemethods
+//
+
+//_____________________________________________________________________________
+void TMCRootManager::OpenFile(
+  const char* projectName, FileMode fileMode, Int_t threadRank)
+{
+  TString fileName(projectName);
+  if (threadRank >= 0) {
+    fileName += "_";
+    fileName += threadRank;
+  }
+  fileName += ".root";
+
+  TString treeTitle(projectName);
+  treeTitle += " tree";
+
+  switch (fileMode) {
+    case TMCRootManager::kRead:
+      fFile = new TFile(fileName);
+      fTree = (TTree*)fFile->Get(projectName);
+      break;
+
+    case TMCRootManager::kWrite:
+      if (fgDebug) printf("Going to create Root file \n");
+      fFile = new TFile(fileName, "recreate");
+      if (fgDebug) printf("Done: file %p \n", fFile);
+
+      if (fgDebug) printf("Going to create TTree \n");
+      fTree = new TTree(projectName, treeTitle);
+      if (fgDebug) printf("Done: TTree %p \n", fTree);
+      ;
+      ;
+  }
+}
+
+//
+// public methods
+//
+
+//_____________________________________________________________________________
+void TMCRootManager::Register(
+  const char* name, const char* className, void* objAddress)
+{
+  /// Create a branch and associates it with the given address.
+  /// \param name       The branch name
+  /// \param className  The class name of the object
+  /// \param objAddress The object address
+
+  fFile->cd();
+  if (!fTree->GetBranch(name))
+    fTree->Branch(name, className, objAddress, 32000, 99);
+  else
+    fTree->GetBranch(name)->SetAddress(objAddress);
+}
+
+//_____________________________________________________________________________
+void TMCRootManager::Register(
+  const char* name, const char* className, const void* objAddress)
+{
+  /// Create a branch and associates it with the given address.
+  /// \param name       The branch name
+  /// \param className  The class name of the object
+  /// \param objAddress The object address
+
+  Register(name, className, const_cast<void*>(objAddress));
+}
+
+//_____________________________________________________________________________
+void TMCRootManager::Fill()
+{
+  /// Fill the Root tree.
+
+  fFile->cd();
+  fTree->Fill();
+}
+
+//_____________________________________________________________________________
+void TMCRootManager::WriteAll()
+{
+  /// Write the Root tree in the file.
+
+  fFile->cd();
+  fFile->Write();
+}
+
+//_____________________________________________________________________________
+void TMCRootManager::Close()
+{
+  /// Close the Root file.
+
+  if (fIsClosed) {
+    Error("Close", "The file was already closed.");
+    return;
+  }
+
+  fFile->cd();
+  fFile->Close();
+  fIsClosed = true;
+}
+
+//_____________________________________________________________________________
+void TMCRootManager::WriteAndClose()
+{
+  /// Write the Root tree in the file and close the file
+
+  WriteAll();
+  Close();
+}
+
+//_____________________________________________________________________________
+void TMCRootManager::ReadEvent(Int_t i)
+{
+  /// Read the event data for \em i -th event for all connected branches.
+  /// \param i  The event to be read
+
+  fTree->GetEntry(i);
+}


### PR DESCRIPTION
This allows to remove the "MTRoot" package from geant4_vmc and so
simplify building of examples and tests