### PR TITLE
Updated cmake_minimum_required in all CMake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 endif()
 
 #--- Define CMake requirements -------------------------------------------------
-cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16...3.27)
 
 #--- Prepend our own CMake Modules to the search path --------------------------
 set(CMAKE_MODULE_PATH 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -11,7 +11,7 @@
 # I. Hrivnacova, 09/04/2019
 
 #---CMake required version -----------------------------------------------------
-#cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16...3.27)
 
 #----------------------------------------------------------------------------
 # Define installed names


### PR DESCRIPTION
- Required: VERSION 3.16...3.27 (as in Geant4 11.3)